### PR TITLE
use JetBrains

### DIFF
--- a/zh_Hans/README.md
+++ b/zh_Hans/README.md
@@ -80,7 +80,7 @@ MVP portal 也同样提供了这样一个简要的清单，从各个方面解答
 - Visual Studio Enterprise 订阅
 - Office 365
 - Github Pro
-- Jetbrain 全家桶授权
+- JetBrains 全家桶授权
 - Visual Assist X 免费 NFR 授权
 - Telerik 免费 NFR 授权
 - DevExpress 免费 NFR 授权
@@ -215,15 +215,15 @@ MVP portal 也同样提供了这样一个简要的清单，从各个方面解答
 
 经过一小段时间的等待，你便可以在 CN 的账号之下管理这个 Super rich subscription 了。
 
-### Jebbrain 福利申请
+### JetBrains 福利申请
 
-请前往：https://www.jetbrains.com/shop/eform/devrecognition?wt.mc_id=MVP_373702
+请前往：https://www.jetbrains.com/shop/eform/devrecognition
 
 填写申请福利的表单，审核通过后即可收到绑定激活邮件。
 
-### Jetbrain 付费插件
+### JetBrains 付费插件
 
-Jetbrain 全家桶权益，不仅仅包含了 Jetbrain 所有的 IDE。实际上还包含了部分插件商城中的付费插件。
+JetBrains 全家桶权益，不仅仅包含了 JetBrains 所有的 IDE。实际上还包含了部分插件商城中的付费插件。
 
 即，MVP 同样也可以申请免费的部分付费插件许可。
 


### PR DESCRIPTION
- `JetBrains` should be the formal name to use, update `jetbrain` to `JetBrains`
- remove the contributorId for the JetBrains link, unnecessary and would not be tracked

https://en.wikipedia.org/wiki/JetBrains